### PR TITLE
Install and configre ruff 

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,10 +1,10 @@
-[flake8]
-; Taken from https://black.readthedocs.io/en/stable/compatible_configs.html#flake8
+# [flake8]
+# ; Taken from https://black.readthedocs.io/en/stable/compatible_configs.html#flake8
 
-extend-ignore = E203,E501,W503
-select = B,C,E,F,W,T4,B9
+# extend-ignore = E203,E501,W503
+# select = B,C,E,F,W,T4,B9
 
-# TODO: fix this
-max-line-length = 140
+# # TODO: fix this
+# max-line-length = 140
 
-max-complexity = 18
+# max-complexity = 18

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 *.pyc
 .vscode
 logs
-db.sqlite3
+*.sqlite3
+*.sqlite
 media/
 venv/
 __pycache__/
@@ -11,3 +12,4 @@ __pycache__/
 db_m.py
 .python-version
 .pytest_cache/
+.ruff_cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,16 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 22.10.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.3
     hooks:
-      - id: black
-        args: [--line-length=77]
+        - id: ruff
+          alias: autoformat
+          args: [--fix]
+        - id: ruff-format
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.11.5
     hooks:
       - id: isort
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
-    hooks:
-      - id: flake8
-        additional_dependencies: [flake8-bugbear]
 
   - repo: https://github.com/pycqa/bandit
     rev: 1.7.4

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,37 @@
+# https://docs.astral.sh/ruff/tutorial/#configuration
+# https://docs.astral.sh/ruff/settings/
+# Set the maximum line length to 79.
+line-length = 79
+
+[lint]
+select = [
+    "B",  # flake8-bugbear
+    "C",
+    "DJ", # flake8-django
+    "E",  # pycodestyle
+    "F",  # PyflakesØ
+    "I",  # isort
+    "PL", # pylint
+    "UP", # pyupgrade
+    "W",
+    "B9",
+]
+ignore = ["E203", "E501", "B904", "DJ001", "W191"]
+
+
+# Add the `line-too-long` rule to the enforced rule set. By default, Ruff omits rules that
+# overlap with the use of a formatter, like Black, but we can override this behavior by
+# explicitly adding the rule.
+extend-select = ["E501"]
+
+[format]
+indent-style = "space"
+
+[mccabe] # DO NOT INCREASE THIS VALUE
+max-complexity = 18 # default: 10
+
+[pylint]
+max-args = 10
+
+[pycodestyle]
+max-line-length = 88

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Make desired changes then commit the branch.
 
 **If using poetry for dependency management, you can pip freeze them to a `requirements.txt` file by running**
 
-    pip --disable-pip-version-check list --format=freeze > requirements.txt
+    pip --disable-pip-version-check list --format=freeze > requirements.txt or
+    make pip-freeze
 
 ### Creating an App
 
@@ -76,3 +77,28 @@ Make sure to create the `{app_name}` directory before running the command.
 Once created, edit the `app.py` folder name section to be
 
     name = 'task_manager.apps.{app_name}'
+
+## Running Health Checks
+
+Health checks have been configured for each container service to ensure they are running and ready to accept connections.
+
+1. Nginx Services
+
+    docker inspect --format='{{json .State.Health}}' task_manager_web_server
+
+2. Postgres Service
+
+    docker inspect --format='{{json .State.Health}}' task_manager_db
+
+3. Pgadmin Service
+
+    docker inspect --format='{{json .State.Health}}' task_manager_db
+
+Alternatively, you can run check the health status of all containers by running the command `make container-health-check`
+
+### Ruff Resources
+
+1. <https://docs.astral.sh/ruff/>
+2. <https://pypi.org/project/ruff/>
+3. <https://docs.astral.sh/ruff/configuration/>
+4. <https://blog.jerrycodes.com/ruff-the-python-linter/>

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Health checks have been configured for each container service to ensure they are
 
 3. Pgadmin Service
 
-    docker inspect --format='{{json .State.Health}}' task_manager_db
+    docker inspect --format='{{json .State.Health}}' task_manager_pg_admin
 
 Alternatively, you can run check the health status of all containers by running the command `make container-health-check`
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Once created, edit the `app.py` folder name section to be
 
 Health checks have been configured for each container service to ensure they are running and ready to accept connections.
 
-1. Nginx Services
+1. Nginx Service
 
     docker inspect --format='{{json .State.Health}}' task_manager_web_server
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1103,6 +1103,32 @@ requests = ">=2.0.0"
 rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
+name = "ruff"
+version = "0.1.6"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.1.6-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:88b8cdf6abf98130991cbc9f6438f35f6e8d41a02622cc5ee130a02a0ed28703"},
+    {file = "ruff-0.1.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5c549ed437680b6105a1299d2cd30e4964211606eeb48a0ff7a93ef70b902248"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cf5f701062e294f2167e66d11b092bba7af6a057668ed618a9253e1e90cfd76"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:05991ee20d4ac4bb78385360c684e4b417edd971030ab12a4fbd075ff535050e"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87455a0c1f739b3c069e2f4c43b66479a54dea0276dd5d4d67b091265f6fd1dc"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:683aa5bdda5a48cb8266fcde8eea2a6af4e5700a392c56ea5fb5f0d4bfdc0240"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:137852105586dcbf80c1717facb6781555c4e99f520c9c827bd414fac67ddfb6"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd98138a98d48a1c36c394fd6b84cd943ac92a08278aa8ac8c0fdefcf7138f35"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a0cd909d25f227ac5c36d4e7e681577275fb74ba3b11d288aff7ec47e3ae745"},
+    {file = "ruff-0.1.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e8fd1c62a47aa88a02707b5dd20c5ff20d035d634aa74826b42a1da77861b5ff"},
+    {file = "ruff-0.1.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fd89b45d374935829134a082617954120d7a1470a9f0ec0e7f3ead983edc48cc"},
+    {file = "ruff-0.1.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:491262006e92f825b145cd1e52948073c56560243b55fb3b4ecb142f6f0e9543"},
+    {file = "ruff-0.1.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:ea284789861b8b5ca9d5443591a92a397ac183d4351882ab52f6296b4fdd5462"},
+    {file = "ruff-0.1.6-py3-none-win32.whl", hash = "sha256:1610e14750826dfc207ccbcdd7331b6bd285607d4181df9c1c6ae26646d6848a"},
+    {file = "ruff-0.1.6-py3-none-win_amd64.whl", hash = "sha256:4558b3e178145491e9bc3b2ee3c4b42f19d19384eaa5c59d10acf6e8f8b57e33"},
+    {file = "ruff-0.1.6-py3-none-win_arm64.whl", hash = "sha256:03910e81df0d8db0e30050725a5802441c2022ea3ae4fe0609b76081731accbc"},
+    {file = "ruff-0.1.6.tar.gz", hash = "sha256:1b09f29b16c6ead5ea6b097ef2764b42372aebe363722f1605ecbcd2b9207184"},
+]
+
+[[package]]
 name = "setuptools"
 version = "67.8.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -1272,4 +1298,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "306a307aaabd35cc29a89f4a787ad8d485422a422719ea49c59c77184d6cd71e"
+content-hash = "d8216463a2243749bdfd1f5de79c6725b7bfdedde901cfd9370466dfbed5b02b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Ted Ngeene <tngeene27@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "3.8"
+python = ">=3.8, <3.9"
 django = "4.2.2"
 djangorestframework = "3.14.0"
 djoser = "2.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Ted Ngeene <tngeene27@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "3.8"
 django = "4.2.2"
 djangorestframework = "3.14.0"
 djoser = "2.1.0"
@@ -27,6 +27,10 @@ factory-boy = "3.2.1"
 freezegun = "1.2.2"
 pytest = "7.2.2"
 pytest-django = "4.5.2"
+
+
+[tool.poetry.group.dev.dependencies]
+ruff = "0.1.6"
 
 [build-system]
 requires = ["poetry-core"]

--- a/task_manager/api/tests/utils.py
+++ b/task_manager/api/tests/utils.py
@@ -6,7 +6,6 @@ User = get_user_model()
 
 
 def force_authenticate(request, user: User = None, token: Token = None):
-
     if token:
         test.force_authenticate(request, user=user, token=token)
     else:

--- a/task_manager/apps/login/api/v1/tests/conftest.py
+++ b/task_manager/apps/login/api/v1/tests/conftest.py
@@ -17,9 +17,7 @@ def expected_user_response(user):
         "last_name": user.last_name,
         "is_active": user.is_active,
         "date_joined": user.date_joined.isoformat(),
-        "last_login": user.last_login.isoformat()
-        if user.last_login
-        else None,
+        "last_login": user.last_login.isoformat() if user.last_login else None,
     }
 
 

--- a/task_manager/apps/login/managers.py
+++ b/task_manager/apps/login/managers.py
@@ -14,6 +14,4 @@ class UserAccountManager(UserManager):
         return super().create_user(email, email, password, **extra_fields)
 
     def create_superuser(self, email=None, password=None, **extra_fields):
-        return super().create_superuser(
-            email, email, password, **extra_fields
-        )
+        return super().create_superuser(email, email, password, **extra_fields)

--- a/task_manager/apps/login/migrations/0001_initial.py
+++ b/task_manager/apps/login/migrations/0001_initial.py
@@ -8,7 +8,6 @@ import task_manager.apps.login.managers
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [
@@ -30,9 +29,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "password",
-                    models.CharField(
-                        max_length=128, verbose_name="password"
-                    ),
+                    models.CharField(max_length=128, verbose_name="password"),
                 ),
                 (
                     "last_login",

--- a/task_manager/apps/login/migrations/0002_useraccount_role.py
+++ b/task_manager/apps/login/migrations/0002_useraccount_role.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("login", "0001_initial"),
     ]

--- a/task_manager/apps/login/migrations/0003_alter_useraccount_role.py
+++ b/task_manager/apps/login/migrations/0003_alter_useraccount_role.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("login", "0002_useraccount_role"),
     ]

--- a/task_manager/apps/login/migrations/0004_alter_useraccount_gender.py
+++ b/task_manager/apps/login/migrations/0004_alter_useraccount_gender.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("login", "0003_alter_useraccount_role"),
     ]

--- a/task_manager/apps/login/views.py
+++ b/task_manager/apps/login/views.py
@@ -1,3 +1,1 @@
-from django.shortcuts import render
-
 # Create your views here.

--- a/task_manager/apps/tasks/admin.py
+++ b/task_manager/apps/tasks/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
 # Register your models here.

--- a/task_manager/apps/tasks/models.py
+++ b/task_manager/apps/tasks/models.py
@@ -1,3 +1,1 @@
-from django.db import models
-
 # Create your models here.

--- a/task_manager/apps/tasks/tests.py
+++ b/task_manager/apps/tasks/tests.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
-
 # Create your tests here.

--- a/task_manager/apps/tasks/views.py
+++ b/task_manager/apps/tasks/views.py
@@ -1,3 +1,1 @@
-from django.shortcuts import render
-
 # Create your views here.


### PR DESCRIPTION
### Description of the PR
The changes introduced replace the default linter and formatter from black to [Ruff](https://docs.astral.sh/ruff/).
We install Ruff as a dev dependency and install the pre-commit hook.

The modified files have been formatted by Ruff.
### Acceptance Criteria

### Manual Testing Plan
1. Update dependencies by running `poetry install` to install Ruff
2. Modify any python file.

For ruff to format and lint files, you can either 

1. Manually run ruff by running the commands 

```
 ruff check . --fix  <-- this only performs linting checks
 ruff format .   <--- format 
```
 you can run lint check in dry run mode by omitting the `--fix` flag and it will output the changes that need to be updated without linting.

2. Make all necessary changes to the desired files and commit. The pre-commit hook will perform both linting and formatting. 

### Post Deployment Checks

### Risk

- [x] Low (Code changes will not impact clients or customers)
- [ ] Medium (Code changes impact specific services)
- [ ] High (Code changes impact the entire platform)

#### Description of risk

### Logging and Monitoring

### Related Documentation
